### PR TITLE
Support Writable instead of WriteStream

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import fs = require('fs');
 import { TBufferedTransport, TCompactProtocol, TFramedTransport } from 'thrift';
 import { FileMetaData, PageHeader } from './thrift';
+import { Writable } from 'stream';
 
 export interface WriteStreamOptions {
   flags?: string;
@@ -144,7 +145,7 @@ export function fclose(fd: number): Promise<void> {
   });
 }
 
-export function oswrite(os: fs.WriteStream, buf: Buffer): Promise<void> {
+export function oswrite(os: Writable, buf: Buffer): Promise<void> {
   return new Promise((resolve, reject) => {
     os.write(buf, (err) => {
       if (err) {
@@ -156,7 +157,7 @@ export function oswrite(os: fs.WriteStream, buf: Buffer): Promise<void> {
   });
 }
 
-export function osclose(os: fs.WriteStream): Promise<void> {
+export function osclose(os: Writable): Promise<void> {
   return new Promise((resolve, reject) => {
     (os as any).close((err: any) => {
       if (err) {

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -1,5 +1,4 @@
-import { WriteStream } from 'fs';
-import { Transform } from 'stream';
+import { Transform, Writable } from 'stream';
 import { ParquetCodecOptions, PARQUET_CODEC } from './codec';
 import * as Compression from './compression';
 import { ParquetBuffer, ParquetCodec, ParquetData, ParquetField, PrimitiveType } from './declare';
@@ -67,7 +66,7 @@ export class ParquetWriter<T> {
    * Convenience method to create a new buffered parquet writer that writes to
    * the specified stream
    */
-  static async openStream<T>(schema: ParquetSchema, outputStream: WriteStream, opts?: ParquetWriterOptions): Promise<ParquetWriter<T>> {
+  static async openStream<T>(schema: ParquetSchema, outputStream: Writable, opts?: ParquetWriterOptions): Promise<ParquetWriter<T>> {
     if (!opts) {
       // tslint:disable-next-line:no-parameter-reassignment
       opts = {};
@@ -188,7 +187,7 @@ export class ParquetEnvelopeWriter {
   /**
    * Create a new parquet envelope writer that writes to the specified stream
    */
-  static async openStream(schema: ParquetSchema, outputStream: WriteStream, opts: ParquetWriterOptions): Promise<ParquetEnvelopeWriter> {
+  static async openStream(schema: ParquetSchema, outputStream: Writable, opts: ParquetWriterOptions): Promise<ParquetEnvelopeWriter> {
     const writeFn = Util.oswrite.bind(undefined, outputStream);
     const closeFn = Util.osclose.bind(undefined, outputStream);
     return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);


### PR DESCRIPTION
Writable is a superclass of WriteStream so this supports more use cases, e.g. writing to an HTTP response in an HTTP server.