### PR TITLE
Support AsyncIterable protocol on cursor

### DIFF
--- a/src/reader.ts
+++ b/src/reader.ts
@@ -27,7 +27,7 @@ const PARQUET_RDLVL_ENCODING = 'RLE';
 /**
  * A parquet cursor is used to retrieve rows from a parquet file in order
  */
-export class ParquetCursor<T> {
+export class ParquetCursor<T> implements AsyncIterable<T> {
 
   public metadata: FileMetaData;
   public envelopeReader: ParquetEnvelopeReader;
@@ -78,6 +78,34 @@ export class ParquetCursor<T> {
     this.rowGroup = [];
     this.rowGroupIndex = 0;
   }
+
+  /**
+   * Implement AsyncIterable
+   */
+  // tslint:disable-next-line:function-name
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    let done = false;
+    return {
+      next: async () => {
+        if (done) {
+          return { done, value: null };
+        }
+        const value = await this.next();
+        if (value === null) {
+          return { done: true, value };
+        }
+        return { done: false, value };
+      },
+      return: async () => {
+        done = true;
+        return { done, value: null };
+      },
+      throw: async () => {
+        done = true;
+        return { done: true, value: null };
+      }
+    };
+  }
 }
 
 /**
@@ -87,7 +115,7 @@ export class ParquetCursor<T> {
  * important that you call close() after you are finished reading the file to
  * avoid leaking file descriptors.
  */
-export class ParquetReader<T> {
+export class ParquetReader<T> implements AsyncIterable<T> {
 
   /**
    * Open the parquet file pointed to by the specified path and return a new
@@ -137,6 +165,7 @@ export class ParquetReader<T> {
    * names means that only those columns should be loaded from disk.
    */
   getCursor(): ParquetCursor<T>;
+  getCursor<K extends keyof T>(columnList: (K | K[])[]): ParquetCursor<Pick<T, K>>;
   getCursor(columnList: (string | string[])[]): ParquetCursor<Partial<T>>;
   getCursor(columnList?: (string | string[])[]): ParquetCursor<Partial<T>> {
     if (!columnList) {
@@ -189,6 +218,14 @@ export class ParquetReader<T> {
     await this.envelopeReader.close();
     this.envelopeReader = null;
     this.metadata = null;
+  }
+
+  /**
+   * Implement AsyncIterable
+   */
+  // tslint:disable-next-line:function-name
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return this.getCursor()[Symbol.asyncIterator]();
   }
 }
 

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -3,6 +3,7 @@ import { ParquetCompression } from '../src';
 import chai = require('chai');
 import fs = require('fs');
 import parquet = require('../src');
+import { promisify } from 'util';
 const assert = chai.assert;
 const objectStream = require('object-stream');
 
@@ -52,7 +53,7 @@ function mkTestSchema(opts: TestOptions) {
   });
 }
 
-function mkTestRows(opts?: TestOptions) {
+function mkTestRows() {
   const rows: any[] = [];
 
   for (let i = 0; i < TEST_NUM_ROWS; i++) {
@@ -124,7 +125,7 @@ async function writeTestFile(opts: TestOptions) {
   writer.setMetadata('myuid', '420');
   writer.setMetadata('fnord', 'dronf');
 
-  const rows = mkTestRows(opts);
+  const rows = mkTestRows();
 
   for (const row of rows) {
     await writer.appendRow(row);
@@ -403,7 +404,7 @@ async function readTestFile() {
     assert.equal(await cursor.next(), null);
   }
 
-  reader.close();
+  await reader.close();
 }
 
 // tslint:disable:ter-prefer-arrow-callback
@@ -490,6 +491,35 @@ describe('Parquet', function () {
       const ostream = fs.createWriteStream('fruits_stream.parquet');
       const istream = objectStream.fromArray(mkTestRows());
       istream.pipe(transform).pipe(ostream);
+      await promisify(ostream.on.bind(ostream, 'finish'))();
+      await readTestFile();
     });
   });
+
+  if ('asyncIterator' in Symbol) {
+    describe('using the AsyncIterable API', function () {
+      it('allows iteration on a cursor using for-await-of', async function () {
+        await writeTestFile({ useDataPageV2: true, compression: 'GZIP' });
+        const reader = await parquet.ParquetReader.openFile<{ name: string }>('fruits.parquet');
+
+        async function checkTestDataUsingForAwaitOf(cursor: AsyncIterable<{ name: string }>) {
+          const names: Set<string> = new Set();
+          let rowCount = 0;
+          for await (const row of cursor) {
+            names.add(row.name);
+            rowCount++;
+          }
+          assert.equal(rowCount, TEST_NUM_ROWS * names.size);
+          assert.deepEqual(names, new Set(['apples', 'oranges', 'kiwi', 'banana']));
+        }
+
+        // Works with reader (will return all columns)
+        await checkTestDataUsingForAwaitOf(reader);
+
+        // Works with a cursor
+        const cursor = reader.getCursor(['name']);
+        await checkTestDataUsingForAwaitOf(cursor);
+      });
+    });
+  }
 });


### PR DESCRIPTION
This allows one to use the nice for-await-of syntax on a cursor or reader or use async iterator processing libraries.