### PR TITLE
Add prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "lzo": "^0.4.11",
     "node-snappy": "^0.1.4",
     "object-stream": "0.0.1",
+    "prettier": "^2.1.2",
     "snappy": "6.2.3",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
@@ -96,5 +97,9 @@
       "json",
       "node"
     ]
+  },
+  "prettier": {
+    "arrowParens": "avoid",
+    "singleQuote": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
         "trailing-comma": false,
         "prefer-template": false,
         "no-else-after-return": false,
+        "ter-computed-property-spacing": false,
         "max-line-length": [
             true,
             200


### PR DESCRIPTION
Also change one tslint rule that prettier seems to like to trigger.

I've been trying to work on a few changes to parquet-ts and I really missing having prettier available to reformat code to spec.  I hope you will adopt prettier.
