### PR TITLE
Mark "fs" package as disabled in browser builds (e.g. webpack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "homepage": "https://github.com/kbajalc/parquets",
   "author": "kbajalc@gmail.com",
   "license": "MIT",
+  "browser": {
+    "fs": false
+  },
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "source": "./src/index.ts",


### PR DESCRIPTION
Adding this option helps build projects that use parquets in webpack.