### PR TITLE
encodeColumnChunk minor cleanup

### DIFF
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -531,12 +531,8 @@ function encodeColumnChunk(
   });
 
   /* list encodings */
-  const encodingsSet: Record<string, boolean> = {};
-  encodingsSet[PARQUET_RDLVL_ENCODING] = true;
-  encodingsSet[column.encoding] = true;
-  for (const k in encodingsSet) {
-    metadata.encodings.push((Encoding as any)[k]);
-  }
+  metadata.encodings.push(Encoding[PARQUET_RDLVL_ENCODING]);
+  metadata.encodings.push(Encoding[column.encoding]);
 
   /* concat metadata header and data pages */
   const metadataOffset = baseOffset + pageBuf.length;


### PR DESCRIPTION
This logic seemed like it could be simplified to just push the two values onto the array instead of constructing an object with two known keys and looping over those two keys.