### PR TITLE
Allow writing an empty parquet file

### DIFF
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -254,14 +254,6 @@ export class ParquetEnvelopeWriter {
       userMetadata = {};
     }
 
-    if (this.rowCount === 0) {
-      throw new Error('cannot write parquet file with zero rows');
-    }
-
-    if (this.schema.fieldList.length === 0) {
-      throw new Error('cannot write parquet file with zero fieldList');
-    }
-
     return this.writeSection(encodeFooter(this.schema, this.rowCount, this.rowGroups, userMetadata));
   }
 

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -421,6 +421,24 @@ describe('Parquet', function () {
       return writeTestFile(opts).then(readTestFile);
     });
 
+    it('write an empty test file and then read it back', async function () {
+      const opts: TestOptions = { useDataPageV2: false, compression: 'UNCOMPRESSED' };
+      const schema = mkTestSchema(opts);
+      const writer = await parquet.ParquetWriter.openFile(schema, 'empty.parquet', opts);
+      await writer.close();
+      const reader = await parquet.ParquetReader.openFile('empty.parquet');
+      expect(reader.getRowCount()).toBe(0);
+    });
+
+    it('write an empty test file with empty schema and then read it back', async function () {
+      const opts: TestOptions = { useDataPageV2: false, compression: 'UNCOMPRESSED' };
+      const schema = new parquet.ParquetSchema({});
+      const writer = await parquet.ParquetWriter.openFile(schema, 'empty.parquet', opts);
+      await writer.close();
+      const reader = await parquet.ParquetReader.openFile('empty.parquet');
+      expect(reader.getRowCount()).toBe(0);
+    });
+
     it('write a test file with GZIP compression and then read it back', function () {
       const opts: TestOptions = { useDataPageV2: false, compression: 'GZIP' };
       return writeTestFile(opts).then(readTestFile);
@@ -453,6 +471,23 @@ describe('Parquet', function () {
       return writeTestFile(opts).then(readTestFile);
     });
 
+    it('write an empty test file and then read it back', async function () {
+      const opts: TestOptions = { useDataPageV2: true, compression: 'UNCOMPRESSED' };
+      const schema = mkTestSchema(opts);
+      const writer = await parquet.ParquetWriter.openFile(schema, 'empty.parquet', opts);
+      await writer.close();
+      const reader = await parquet.ParquetReader.openFile('empty.parquet');
+      expect(reader.getRowCount()).toBe(0);
+    });
+
+    it('write an empty test file with empty schema and then read it back', async function () {
+      const opts: TestOptions = { useDataPageV2: true, compression: 'UNCOMPRESSED' };
+      const schema = new parquet.ParquetSchema({});
+      const writer = await parquet.ParquetWriter.openFile(schema, 'empty.parquet', opts);
+      await writer.close();
+      const reader = await parquet.ParquetReader.openFile('empty.parquet');
+      expect(reader.getRowCount()).toBe(0);
+    });
     it('write a test file with GZIP compression and then read it back', function () {
       const opts: TestOptions = { useDataPageV2: true, compression: 'GZIP' };
       return writeTestFile(opts).then(readTestFile);


### PR DESCRIPTION
Sometimes you just don't have any data to send but you want to send a file anyway and it's inconvenient to come up with some separate way to indicate no data.